### PR TITLE
Revert "lint code only for main go version"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,6 @@ jobs:
       run: go test -test.count=10 -race -covermode atomic -coverprofile=covprofile.out  ./...
 
     - name: golangci-lint
-      if: ${{ matrix.goVersion == env.GO_VERSION }}
       uses: golangci/golangci-lint-action@v2
       with:
         version: latest


### PR DESCRIPTION
This reverts commit 26569dc625c5b2aa19bf0fc1aaa432c8435cda77.